### PR TITLE
Fix QueryList syntax in Windows event channel example

### DIFF
--- a/source/user-manual/capabilities/log-data-collection/configuration.rst
+++ b/source/user-manual/capabilities/log-data-collection/configuration.rst
@@ -78,12 +78,12 @@ You can configure Wazuh agent to collect specific Windows events from the Window
       <localfile>
         <location>System</location>
         <log_format>eventchannel</log_format>
-         <query>
-           \<QueryList>
-             \<Query Id="0" Path="System">
-               \<Select Path="System">*[System[(Level&lt;=3)]]\</Select>
-                \</Query>
-              \</QueryList>
+        <query>
+          \<QueryList>
+            \<Query Id="0" Path="System">
+              \<Select Path="System">*[System[(Level&lt;=3)]]\</Select>
+            \</Query>
+          \</QueryList>
         </query>
       </localfile>
 

--- a/source/user-manual/capabilities/log-data-collection/configuration.rst
+++ b/source/user-manual/capabilities/log-data-collection/configuration.rst
@@ -73,17 +73,17 @@ Monitoring specific events from Windows event channel
 
 You can configure Wazuh agent to collect specific Windows events from the Windows event channel using queries. For example, the following configuration collects Windows events from the ``System`` channel whose levels are equal to or less than 3 (warning):
 
-   .. code-block:: none
+   .. code-block:: xml
 
       <localfile>
         <location>System</location>
         <log_format>eventchannel</log_format>
          <query>
-           \<QueryList\>
-             \<Query Id="0" Path="System"\>
-               \<Select Path="System"\>*[System[(Level&lt;=3)]]\</Select\>
-                \</Query\>
-              \</QueryList\>
+           \<QueryList>
+             \<Query Id="0" Path="System">
+               \<Select Path="System">*[System[(Level&lt;=3)]]\</Select>
+                \</Query>
+              \</QueryList>
         </query>
       </localfile>
 


### PR DESCRIPTION
## Description

The example on how to use QueryList to filter collected logs from Windows event channels uses incorrect escaping for the  XML-tags. Only the `<` (lesser-than) symbols in the XML-tags have to be escaped, as per different examples from issues or the mailinglist

When using the inoccrect escaping, e.g. `\<QueryList\>`, the query is not applied and no events get forwarded.

This PR fixes the related documentation.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
